### PR TITLE
Create a workflow that can publish to PyPI

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs: []
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Build source dist
+        run: python setup.py sdist
+        
+      - name: Publish package to TestPyPI
+#         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Must be manually triggered, and can only publish to test.pypi.org for now