### PR TITLE
Backport 3.11's `fromiso8601` methods

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.6
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
 
       - name: Install lint tools
         run: 'pip install Pygments restructuredtext-lint'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.6
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -23,6 +23,26 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: python setup.py test
+
+  build-old:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: ["3.4", "3.5"]
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Requires explicit pytz installation
+      - run: pip install pytz
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.4", "3.5"]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -42,6 +42,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Requires explicit pytz installation
+      - run: pip install pytz
+
       - run: pip install pytz
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: python setup.py test
+        run: STRICT_WARNINGS=1 python setup.py test
 
   build-old:
     runs-on: ubuntu-18.04
@@ -47,4 +47,4 @@ jobs:
       - run: pip install pytz
 
       - name: Run tests
-        run: python setup.py test
+        run: STRICT_WARNINGS=1 python setup.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.4, 3.5, 3.6, 3.7]
+        python-version: ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,29 @@
 <!-- Generated with "Markdown T​O​C" extension for Visual Studio Code -->
 <!-- TOC anchorMode:github.com -->
 
+- [2.x.x](#2xx)
+  - [Migration from 1.x.x](#migration-from-1xx)
+  - [Version 2.0.0](#version-200)
 - [1.x.x](#1xx)
-    - [Version 1.0.0](#version-100)
+  - [Version 1.0.0](#version-100)
 - [0.x.x](#0xx)
-    - [Version 0.0.2](#version-002)
-    - [Version 0.0.1](#version-001)
+  - [Version 0.0.2](#version-002)
+  - [Version 0.0.1](#version-001)
+
+
+# 2.x.x
+
+## Migration from 1.x.x
+
+No migration is needed.
+
+However, starting in version 2, `backports.datetime_fromisoformat` will apply its changes to Python < 3.11, whereas v1 only applied changes to Python < 3.7. If you happened to be using `backports.datetime_fromisoformat` v1 on Python 3.7 through Python 3.10 and then upgrade to v2, it will patch the `fromisoformat` methods, whereas in v1 it did not. The `fromisoformat` methods will be able to parse timestamps from a wider portion of the ISO 8601 specification. This is unlikely to be a problem, but for completeness it is mentioned here.
+
+## Version 2.0.0
+
+* Backport the logic from Python 3.11's `fromisoformat` methods, instead of Python 3.7's, [#22](https://github.com/movermeyer/backports.datetime_fromisoformat/pull/22)
+  * Adds support for a wider portion of the ISO 8601 specification
+  * Backports are now applied to Python < 3.11, instead of only Python < 3.7
 
 # 1.x.x
 

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ backports.datetime_fromisoformat
 .. image:: https://github.com/movermeyer/backports.datetime_fromisoformat/workflows/Tests/badge.svg
     :target: https://github.com/movermeyer/backports.datetime_fromisoformat/workflows/Tests
 
-A backport of Python 3.7's ``datetime.fromisoformat`` methods to earlier versions of Python 3. 
-Tested against Python 3.4, 3.5 and 3.6.
+A backport of Python 3.11's ``datetime.fromisoformat`` methods to earlier versions of Python 3.
+Tested against Python 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 
 Current Status
 --------------
@@ -42,22 +42,25 @@ Quick Start
 Explanation
 -----------
 In Python 3.7, `datetime.fromisoformat`_ was added. It is the inverse of `datetime.isoformat`_.
-Similar methods were added to the ``date`` and ``time`` types as well. 
+Similar methods were added to the ``date`` and ``time`` types as well.
+
+In Python 3.11, `datetime.fromisoformat`_ was extended to cover (almost) all of the ISO 8601 specification, making it generally useful.
+
 For those who need to support earlier versions of Python, a backport of these methods was needed.
 
 .. _`datetime.fromisoformat`: https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
 
 .. _`datetime.isoformat`: https://docs.python.org/3/library/datetime.html#datetime.date.isoformat
 
-``backports.datetime_fromisoformat`` is a C implementation of ``fromisoformat`` based on the upstream cPython 3.7 code.
+``backports.datetime_fromisoformat`` is a C implementation of ``fromisoformat`` based on the upstream cPython 3.11 code.
 For timezone objects, it uses a custom ``timezone`` C implementation (originally from `Pendulum`_).
 
 .. _`Pendulum`: https://pendulum.eustace.io/
 
-Usage in Python 3.7+
---------------------
+Usage in Python 3.11+
+---------------------
 
-NOTE: in Python 3.7 and later, the ``fromisoformat`` methods exist in the stdlib, and installing this package has NO EFFECT.
+NOTE: in Python 3.11 and later, compatible versions of ``fromisoformat`` methods exist in the stdlib, and installing this package has NO EFFECT.
 
 Goal / Project Scope
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,19 @@ Current Status
 
 Development of ``backports.datetime_fromisoformat`` is "complete". Outside of potential minor bug fixes, do not expect new development here.
 
+Version 2 changes
+-----------------
+
+In version 1, ``backports.datetime_fromisoformat`` was a backport of the Python 3.7 version of the ``fromisoformat`` methods.
+This meant that it was limited in being able to parse only timestamps that were in the format produced by ``datetime.isoformat``.
+
+As of version 2, ``backports.datetime_fromisoformat`` is a backport of the Python 3.11 version of the ``fromisoformat`` methods, which can parse (almost) the entire ISO 8601 specification.
+There are no changes required when upgrading from v1 to v2. The parser is simply able to parse a wider portion of the ISO 8601 specification.
+
+However, starting in version 2, ``backports.datetime_fromisoformat`` will apply its changes to Python < 3.11, whereas v1 only applied changes to Python < 3.7.
+If you happened to be using ``backports.datetime_fromisoformat`` v1 on Python 3.7 through Python 3.10 and then upgrade to v2, it will patch the ``fromisoformat`` methods, whereas in v1 it did not.
+The result is that the ``fromisoformat`` methods will suddenly be able to parse timestamps from a wider portion of the ISO 8601 specification.
+
 Quick Start
 -----------
 

--- a/backports/datetime_fromisoformat/__init__.py
+++ b/backports/datetime_fromisoformat/__init__.py
@@ -27,22 +27,14 @@ class MonkeyPatch(object):
 
         from datetime import date, datetime, time
 
-        try:
-            _ = datetime.fromisoformat
-        except AttributeError:
+        if sys.version_info.major >= 3 and sys.version_info < (3, 11):
             d = _get_dict(datetime)[0]
             d['fromisoformat'] = datetime_fromisoformat
 
-        try:
-            _ = date.fromisoformat
-        except AttributeError:
             d = _get_dict(date)[0]
             d['fromisoformat'] = date_fromisoformat
 
-        try:
-            _ = time.fromisoformat
-        except AttributeError:
             d = _get_dict(time)[0]
             d['fromisoformat'] = time_fromisoformat
 
-        flush_mro_cache()
+            flush_mro_cache()

--- a/backports/datetime_fromisoformat/_datetimemodule.c
+++ b/backports/datetime_fromisoformat/_datetimemodule.c
@@ -1,6 +1,8 @@
-/* This file was originally taken from cPython 3.7's code base
+/* This file was originally taken from cPython's code base
  * (`Modules/_datetimemodule.c`). (2018-06-10 18:02:24, commit SHA-1:
  * 037e9125527d4a55af566f161c96a61b3c3fd998)
+ * It was then refreshed using the Python 3.11 contents present at
+ * 27d8dc2c9d3de886a884f79f0621d4586c0e0f7a
  *
  * Since then, I have:
  *   - torn out all the functionality that doesn't matter to
@@ -9,53 +11,51 @@
  *     `PyDateTimeAPI`
  *   - made minor changes to make it compilable for older versions of Python.
  *
- * Below is a copy of the Python 3.7 code license
+ * Below is a copy of the Python 3.11 code license
  * (from https://docs.python.org/3/license.html):
  *
- * PSF LICENSE AGREEMENT FOR PYTHON 3.7.0
+ * PSF LICENSE AGREEMENT FOR PYTHON 3.11.0
  *
- * 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"),
- *    and the Individual or Organization ("Licensee") accessing and otherwise
- *    using Python 3.7.0 software in source or binary form and its associated
- *    documentation.
+ * 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+ *    the Individual or Organization ("Licensee") accessing and otherwise using Python
+ *    3.11.0 software in source or binary form and its associated documentation.
  *
  * 2. Subject to the terms and conditions of this License Agreement, PSF hereby
- *    grants Licensee a nonexclusive, royalty-free, world-wide license to
- *    reproduce, analyze, test, perform and/or display publicly, prepare
- *    derivative works, distribute, and otherwise use Python 3.7.0 alone or in
- *    any derivative version, provided, however, that PSF's License Agreement
- *    and PSF's notice of copyright, i.e., "Copyright © 2001-2018 Python
- *    Software Foundation; All Rights Reserved" are retained in Python 3.7.0
- *    alone or in any derivative version prepared by Licensee.
+ *    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+ *    analyze, test, perform and/or display publicly, prepare derivative works,
+ *    distribute, and otherwise use Python 3.11.0 alone or in any derivative
+ *    version, provided, however, that PSF's License Agreement and PSF's notice of
+ *    copyright, i.e., "Copyright © 2001-2022 Python Software Foundation; All Rights
+ *    Reserved" are retained in Python 3.11.0 alone or in any derivative version
+ *    prepared by Licensee.
  *
  * 3. In the event Licensee prepares a derivative work that is based on or
- *    incorporates Python 3.7.0 or any part thereof, and wants to make the
- *    derivative work available to others as provided herein, then Licensee
- *    hereby agrees to include in any such work a brief summary of the changes
- *    made to Python 3.7.0.
+ *    incorporates Python 3.11.0 or any part thereof, and wants to make the
+ *    derivative work available to others as provided herein, then Licensee hereby
+ *    agrees to include in any such work a brief summary of the changes made to Python
+ *    3.11.0.
  *
- * 4. PSF is making Python 3.7.0 available to Licensee on an "AS IS" basis.
- *    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY
- *    OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY
- *    REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
- *    PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.7.0 WILL NOT INFRINGE ANY
- *    THIRD PARTY RIGHTS.
+ * 4. PSF is making Python 3.11.0 available to Licensee on an "AS IS" basis.
+ *    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+ *    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+ *    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+ *    USE OF PYTHON 3.11.0 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
  *
- * 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.0
- *    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT
- *    OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.0, OR ANY
- *    DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+ * 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.11.0
+ *    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+ *    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.11.0, OR ANY DERIVATIVE
+ *    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
  *
- * 6. This License Agreement will automatically terminate upon a material
- *    breach of its terms and conditions.
+ * 6. This License Agreement will automatically terminate upon a material breach of
+ *    its terms and conditions.
  *
- * 7. Nothing in this License Agreement shall be deemed to create any
- *    relationship of agency, partnership, or joint venture between PSF and
- *    Licensee.  This License Agreement does not grant permission to use PSF
- *    trademarks or trade name in a trademark sense to endorse or promote
- *    products or services of Licensee, or any third party.
+ * 7. Nothing in this License Agreement shall be deemed to create any relationship
+ *    of agency, partnership, or joint venture between PSF and Licensee.  This License
+ *    Agreement does not grant permission to use PSF trademarks or trade name in a
+ *    trademark sense to endorse or promote products or services of Licensee, or any
+ *    third party.
  *
- * 8. By copying, installing or otherwise using Python 3.7.0, Licensee agrees
+ * 8. By copying, installing or otherwise using Python 3.11.0, Licensee agrees
  *    to be bound by the terms and conditions of this License Agreement.
  */
 
@@ -84,7 +84,13 @@
  */
 static const int _days_in_month[] = {
     0, /* unused; this vector uses 1-based indexing */
-    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+};
+
+static const int _days_before_month[] = {
+    0, /* unused; this vector uses 1-based indexing */
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+};
 
 /* year -> 1 if leap year, else 0. */
 static int
@@ -111,10 +117,194 @@ days_in_month(int year, int month)
         return _days_in_month[month];
 }
 
+/* year, month -> number of days in year preceding first day of month */
+static int
+days_before_month(int year, int month)
+{
+    int days;
+
+    assert(month >= 1);
+    assert(month <= 12);
+    days = _days_before_month[month];
+    if (month > 2 && is_leap(year))
+        ++days;
+    return days;
+}
+
+/* year -> number of days before January 1st of year.  Remember that we
+ * start with year 1, so days_before_year(1) == 0.
+ */
+static int
+days_before_year(int year)
+{
+    int y = year - 1;
+    /* This is incorrect if year <= 0; we really want the floor
+     * here.  But so long as MINYEAR is 1, the smallest year this
+     * can see is 1.
+     */
+    assert (year >= 1);
+    return y*365 + y/4 - y/100 + y/400;
+}
+
+/* Number of days in 4, 100, and 400 year cycles.  That these have
+ * the correct values is asserted in the module init function.
+ */
+#define DI4Y    1461    /* days_before_year(5); days in 4 years */
+#define DI100Y  36524   /* days_before_year(101); days in 100 years */
+#define DI400Y  146097  /* days_before_year(401); days in 400 years  */
+
+/* ordinal -> year, month, day, considering 01-Jan-0001 as day 1. */
+static void
+ord_to_ymd(int ordinal, int *year, int *month, int *day)
+{
+    int n, n1, n4, n100, n400, leapyear, preceding;
+
+    /* ordinal is a 1-based index, starting at 1-Jan-1.  The pattern of
+     * leap years repeats exactly every 400 years.  The basic strategy is
+     * to find the closest 400-year boundary at or before ordinal, then
+     * work with the offset from that boundary to ordinal.  Life is much
+     * clearer if we subtract 1 from ordinal first -- then the values
+     * of ordinal at 400-year boundaries are exactly those divisible
+     * by DI400Y:
+     *
+     *    D  M   Y            n              n-1
+     *    -- --- ----        ----------     ----------------
+     *    31 Dec -400        -DI400Y       -DI400Y -1
+     *     1 Jan -399         -DI400Y +1   -DI400Y      400-year boundary
+     *    ...
+     *    30 Dec  000        -1             -2
+     *    31 Dec  000         0             -1
+     *     1 Jan  001         1              0          400-year boundary
+     *     2 Jan  001         2              1
+     *     3 Jan  001         3              2
+     *    ...
+     *    31 Dec  400         DI400Y        DI400Y -1
+     *     1 Jan  401         DI400Y +1     DI400Y      400-year boundary
+     */
+    assert(ordinal >= 1);
+    --ordinal;
+    n400 = ordinal / DI400Y;
+    n = ordinal % DI400Y;
+    *year = n400 * 400 + 1;
+
+    /* Now n is the (non-negative) offset, in days, from January 1 of
+     * year, to the desired date.  Now compute how many 100-year cycles
+     * precede n.
+     * Note that it's possible for n100 to equal 4!  In that case 4 full
+     * 100-year cycles precede the desired day, which implies the
+     * desired day is December 31 at the end of a 400-year cycle.
+     */
+    n100 = n / DI100Y;
+    n = n % DI100Y;
+
+    /* Now compute how many 4-year cycles precede it. */
+    n4 = n / DI4Y;
+    n = n % DI4Y;
+
+    /* And now how many single years.  Again n1 can be 4, and again
+     * meaning that the desired day is December 31 at the end of the
+     * 4-year cycle.
+     */
+    n1 = n / 365;
+    n = n % 365;
+
+    *year += n100 * 100 + n4 * 4 + n1;
+    if (n1 == 4 || n100 == 4) {
+        assert(n == 0);
+        *year -= 1;
+        *month = 12;
+        *day = 31;
+        return;
+    }
+
+    /* Now the year is correct, and n is the offset from January 1.  We
+     * find the month via an estimate that's either exact or one too
+     * large.
+     */
+    leapyear = n1 == 3 && (n4 != 24 || n100 == 3);
+    assert(leapyear == is_leap(*year));
+    *month = (n + 50) >> 5;
+    preceding = (_days_before_month[*month] + (*month > 2 && leapyear));
+    if (preceding > n) {
+        /* estimate is too large */
+        *month -= 1;
+        preceding -= days_in_month(*year, *month);
+    }
+    n -= preceding;
+    assert(0 <= n);
+    assert(n < days_in_month(*year, *month));
+
+    *day = n + 1;
+}
+
+/* year, month, day -> ordinal, considering 01-Jan-0001 as day 1. */
+static int
+ymd_to_ord(int year, int month, int day)
+{
+    return days_before_year(year) + days_before_month(year, month) + day;
+}
+
+/* Day of week, where Monday==0, ..., Sunday==6.  1/1/1 was a Monday. */
+static int
+weekday(int year, int month, int day)
+{
+    return (ymd_to_ord(year, month, day) + 6) % 7;
+}
+
+/* Ordinal of the Monday starting week 1 of the ISO year.  Week 1 is the
+ * first calendar week containing a Thursday.
+ */
+static int
+iso_week1_monday(int year)
+{
+    int first_day = ymd_to_ord(year, 1, 1);     /* ord of 1/1 */
+    /* 0 if 1/1 is a Monday, 1 if a Tue, etc. */
+    int first_weekday = (first_day + 6) % 7;
+    /* ordinal of closest Monday at or before 1/1 */
+    int week1_monday  = first_day - first_weekday;
+
+    if (first_weekday > 3)      /* if 1/1 was Fri, Sat, Sun */
+        week1_monday += 7;
+    return week1_monday;
+}
+
+static int
+iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
+           int *year, int *month, int *day) {
+    if (iso_week <= 0 || iso_week >= 53) {
+        int out_of_range = 1;
+        if (iso_week == 53) {
+            // ISO years have 53 weeks in it on years starting with a Thursday
+            // and on leap years starting on Wednesday
+            int first_weekday = weekday(iso_year, 1, 1);
+            if (first_weekday == 3 || (first_weekday == 2 && is_leap(iso_year))) {
+                out_of_range = 0;
+            }
+        }
+
+        if (out_of_range) {
+            return -2;
+        }
+    }
+
+    if (iso_day <= 0 || iso_day >= 8) {
+        return -3;
+    }
+
+    // Convert (Y, W, D) to (Y, M, D) in-place
+    int day_1 = iso_week1_monday(iso_year);
+
+    int day_offset = (iso_week - 1)*7 + iso_day - 1;
+
+    ord_to_ymd(day_1 + day_offset, year, month, day);
+    return 0;
+}
+
 /* ---------------------------------------------------------------------------
  * Range checkers.
  */
 
+#if !PY_VERSION_AT_LEAST_36
 /* Check that date arguments are in range.  Return 0 if they are.  If they
  * aren't, raise ValueError and return -1.
  */
@@ -164,10 +354,16 @@ check_time_args(int h, int m, int s, int us, int fold)
     }
     return 0;
 }
+#endif
 
 /* ---------------------------------------------------------------------------
  * String parsing utilities and helper functions
  */
+
+static unsigned char
+is_digit(const char c) {
+    return ((unsigned int)(c - '0')) < 10;
+}
 
 static const char *
 parse_digits(const char *ptr, int *var, size_t num_digits)
@@ -186,14 +382,17 @@ parse_digits(const char *ptr, int *var, size_t num_digits)
 }
 
 static int
-parse_isoformat_date(const char *dtstr, int *year, int *month, int *day)
+parse_isoformat_date(const char *dtstr, const size_t len, int *year, int *month, int *day)
 {
     /* Parse the date components of the result of date.isoformat()
      *
      *  Return codes:
      *       0:  Success
      *      -1:  Failed to parse date component
-     *      -2:  Failed to parse dateseparator
+     *      -2:  Inconsistent date separator usage
+     *      -3:  Failed to parse ISO week.
+     *      -4:  Failed to parse ISO day.
+     *      -5, -6: Failure in iso_to_ymd
      */
     const char *p = dtstr;
     p = parse_digits(p, year, 4);
@@ -201,8 +400,42 @@ parse_isoformat_date(const char *dtstr, int *year, int *month, int *day)
         return -1;
     }
 
-    if (*(p++) != '-') {
-        return -2;
+    const unsigned char uses_separator = (*p == '-');
+    if (uses_separator) {
+        ++p;
+    }
+
+    if(*p == 'W') {
+        // This is an isocalendar-style date string
+        p++;
+        int iso_week = 0;
+        int iso_day = 0;
+
+        p = parse_digits(p, &iso_week, 2);
+        if (NULL == p) {
+            return -3;
+        }
+
+        assert(p > dtstr);
+        if ((size_t)(p - dtstr) < len) {
+            if (uses_separator && *(p++) != '-') {
+                return -2;
+            }
+
+            p = parse_digits(p, &iso_day, 1);
+            if (NULL == p) {
+                return -4;
+            }
+        } else {
+            iso_day = 1;
+        }
+
+        int rv = iso_to_ymd(*year, iso_week, iso_day, year, month, day);
+        if (rv) {
+            return -3 + rv;
+        } else {
+            return 0;
+        }
     }
 
     p = parse_digits(p, month, 2);
@@ -210,15 +443,13 @@ parse_isoformat_date(const char *dtstr, int *year, int *month, int *day)
         return -1;
     }
 
-    if (*(p++) != '-') {
+    if (uses_separator && *(p++) != '-') {
         return -2;
     }
-
     p = parse_digits(p, day, 2);
     if (p == NULL) {
         return -1;
     }
-
     return 0;
 }
 
@@ -226,12 +457,15 @@ static int
 parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
                   int *minute, int *second, int *microsecond)
 {
+    *hour = *minute = *second = *microsecond = 0;
     const char *p = tstr;
     const char *p_end = tstr_end;
     int *vals[3] = {hour, minute, second};
     size_t i = 0;
+    // This is initialized to satisfy an erroneous compiler warning.
+    unsigned char has_separator = 1;
 
-    // Parse [HH[:MM[:SS]]]
+    // Parse [HH[:?MM[:?SS]]]
     for (i = 0; i < 3; ++i) {
         p = parse_digits(p, vals[i], 2);
         if (NULL == p) {
@@ -239,33 +473,47 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
         }
 
         char c = *(p++);
+        if (i == 0) {
+            has_separator = (c == ':');
+        }
+
         if (p >= p_end) {
             return c != '\0';
         }
-        else if (c == ':') {
+        else if (has_separator && (c == ':')) {
             continue;
         }
-        else if (c == '.') {
+        else if (c == '.' || c == ',') {
             break;
-        }
-        else {
+        } else if (!has_separator) {
+            --p;
+        } else {
             return -4;  // Malformed time separator
         }
     }
 
-    // Parse .fff[fff]
+    // Parse fractional components
     size_t len_remains = p_end - p;
-    if (!(len_remains == 6 || len_remains == 3)) {
-        return -3;
+    size_t to_parse = len_remains;
+    if (len_remains >= 6) {
+        to_parse = 6;
     }
 
-    p = parse_digits(p, microsecond, len_remains);
+    p = parse_digits(p, microsecond, to_parse);
     if (NULL == p) {
         return -3;
     }
 
-    if (len_remains == 3) {
-        *microsecond *= 1000;
+    static int correction[] = {
+        100000, 10000, 1000, 100, 10
+    };
+
+    if (to_parse < 6) {
+        *microsecond *= correction[to_parse-1];
+    }
+
+    while (is_digit(*p)){
+        ++p; // skip truncated digits
     }
 
     // Return 1 if it's not the end of the string
@@ -291,7 +539,7 @@ parse_isoformat_time(const char *dtstr, size_t dtlen, int *hour, int *minute,
 
     const char *tzinfo_pos = p;
     do {
-        if (*tzinfo_pos == '+' || *tzinfo_pos == '-') {
+        if (*tzinfo_pos == 'Z' || *tzinfo_pos == '+' || *tzinfo_pos == '-') {
             break;
         }
     } while (++tzinfo_pos < p_end);
@@ -313,14 +561,16 @@ parse_isoformat_time(const char *dtstr, size_t dtlen, int *hour, int *minute,
         }
     }
 
-    // Parse time zone component
-    // Valid formats are:
-    //    - +HH:MM           (len  6)
-    //    - +HH:MM:SS        (len  9)
-    //    - +HH:MM:SS.ffffff (len 16)
-    size_t tzlen = p_end - tzinfo_pos;
-    if (!(tzlen == 6 || tzlen == 9 || tzlen == 16)) {
-        return -5;
+    // Special case UTC / Zulu time.
+    if (*tzinfo_pos == 'Z') {
+        *tzoffset = 0;
+        *tzmicrosecond = 0;
+
+        if (*(tzinfo_pos + 1) != '\0') {
+            return -5;
+        } else {
+            return 1;
+        }
     }
 
     int tzsign = (*tzinfo_pos == '-') ? -1 : 1;
@@ -339,6 +589,7 @@ parse_isoformat_time(const char *dtstr, size_t dtlen, int *hour, int *minute,
  * tzinfo helpers.
  */
 
+#if !PY_VERSION_AT_LEAST_36
 /* Ensure that p is None or of a tzinfo subclass.  Return 0 if OK; if not
  * raise TypeError and return -1.
  */
@@ -353,12 +604,25 @@ check_tzinfo_subclass(PyObject *p)
                  Py_TYPE(p)->tp_name);
     return -1;
 }
+#endif
 
 static inline PyObject *
 tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
 {
     PyObject *tzinfo;
     if (rv == 1) {
+        if (abs(tzoffset) >= 86400){
+            PyObject *delta;
+
+            delta = PyDelta_FromDSU(0, tzoffset, 0);
+            PyErr_Format(PyExc_ValueError, "offset must be a timedelta"
+                            " strictly between -timedelta(hours=24) and"
+                            " timedelta(hours=24),"
+                            " not %R.", delta);
+            Py_DECREF(delta);
+            return NULL;
+        }
+
         tzinfo = new_fixed_offset(tzoffset);
     }
     else {
@@ -384,20 +648,22 @@ date_fromisoformat(PyObject *dtstr)
     Py_ssize_t len;
 
     const char *dt_ptr = PyUnicode_AsUTF8AndSize(dtstr, &len);
+    if (dt_ptr == NULL) {
+        goto invalid_string_error;
+    }
 
     int year = 0, month = 0, day = 0;
 
     int rv;
-    if (len == 10) {
-        rv = parse_isoformat_date(dt_ptr, &year, &month, &day);
+    if (len == 7 || len == 8 || len == 10) {
+        rv = parse_isoformat_date(dt_ptr, len, &year, &month, &day);
     }
     else {
         rv = -1;
     }
 
     if (rv < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %s", dt_ptr);
-        return NULL;
+        goto invalid_string_error;
     }
 
 #if !PY_VERSION_AT_LEAST_36
@@ -412,6 +678,9 @@ date_fromisoformat(PyObject *dtstr)
 
     return PyDateTimeAPI->Date_FromDate(year, month, day,
                                         PyDateTimeAPI->DateType);
+invalid_string_error:
+    PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %R", dtstr);
+    return NULL;
 }
 
 PyObject *
@@ -428,14 +697,25 @@ time_fromisoformat(PyObject *tstr)
     Py_ssize_t len;
     const char *p = PyUnicode_AsUTF8AndSize(tstr, &len);
 
+    if (p == NULL) {
+        goto invalid_string_error;
+    }
+
+    // The spec actually requires that time-only ISO 8601 strings start with
+    // T, but the extended format allows this to be omitted as long as there
+    // is no ambiguity with date strings.
+    if (*p == 'T') {
+        ++p;
+        len -= 1;
+    }
+
     int hour = 0, minute = 0, second = 0, microsecond = 0;
     int tzoffset, tzimicrosecond = 0;
     int rv = parse_isoformat_time(p, len, &hour, &minute, &second,
                                   &microsecond, &tzoffset, &tzimicrosecond);
 
     if (rv < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %s", p);
-        return NULL;
+        goto invalid_string_error;
     }
 
     PyObject *tzinfo =
@@ -463,6 +743,166 @@ time_fromisoformat(PyObject *tstr)
 
     Py_DECREF(tzinfo);
     return t;
+
+invalid_string_error:
+    PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %R", tstr);
+    return NULL;
+}
+
+static PyObject *
+_sanitize_isoformat_str(PyObject *dtstr)
+{
+    Py_ssize_t len = PyUnicode_GetLength(dtstr);
+    if (len < 7) {  // All valid ISO 8601 strings are at least 7 characters long
+        return NULL;
+    }
+
+    // `fromisoformat` allows surrogate characters in exactly one position,
+    // the separator; to allow datetime_fromisoformat to make the simplifying
+    // assumption that all valid strings can be encoded in UTF-8, this function
+    // replaces any surrogate character separators with `T`.
+    //
+    // The result of this, if not NULL, returns a new reference
+    const void* const unicode_data = PyUnicode_DATA(dtstr);
+    const int kind = PyUnicode_KIND(dtstr);
+
+    // Depending on the format of the string, the separator can only ever be
+    // in positions 7, 8 or 10. We'll check each of these for a surrogate and
+    // if we find one, replace it with `T`. If there is more than one surrogate,
+    // we don't have to bother sanitizing it, because the function will later
+    // fail when we try to encode the string as ASCII.
+    static const size_t potential_separators[3] = {7, 8, 10};
+    size_t surrogate_separator = 0;
+    for(size_t idx = 0;
+         idx < sizeof(potential_separators) / sizeof(*potential_separators);
+         ++idx) {
+        size_t pos = potential_separators[idx];
+        if (pos > (size_t)len) {
+            break;
+        }
+
+        if(Py_UNICODE_IS_SURROGATE(PyUnicode_READ(kind, unicode_data, pos))) {
+            surrogate_separator = pos;
+            break;
+        }
+    }
+
+    if (surrogate_separator == 0) {
+        Py_INCREF(dtstr);
+        return dtstr;
+    }
+
+    PyObject *str_out = _PyUnicode_Copy(dtstr);
+    if (str_out == NULL) {
+        return NULL;
+    }
+
+    if (PyUnicode_WriteChar(str_out, surrogate_separator, (Py_UCS4)'T')) {
+        Py_DECREF(str_out);
+        return NULL;
+    }
+
+    return str_out;
+}
+
+
+static Py_ssize_t
+_find_isoformat_datetime_separator(const char *dtstr, Py_ssize_t len) {
+    // The valid date formats can all be distinguished by characters 4 and 5
+    // and further narrowed down by character
+    // which tells us where to look for the separator character.
+    // Format    |  As-rendered |   Position
+    // ---------------------------------------
+    // %Y-%m-%d  |  YYYY-MM-DD  |    10
+    // %Y%m%d    |  YYYYMMDD    |     8
+    // %Y-W%V    |  YYYY-Www    |     8
+    // %YW%V     |  YYYYWww     |     7
+    // %Y-W%V-%u |  YYYY-Www-d  |    10
+    // %YW%V%u   |  YYYYWwwd    |     8
+    // %Y-%j     |  YYYY-DDD    |     8
+    // %Y%j      |  YYYYDDD     |     7
+    //
+    // Note that because we allow *any* character for the separator, in the
+    // case where character 4 is W, it's not straightforward to determine where
+    // the separator is — in the case of YYYY-Www-d, you have actual ambiguity,
+    // e.g. 2020-W01-0000 could be YYYY-Www-D0HH or YYYY-Www-HHMM, when the
+    // separator character is a number in the former case or a hyphen in the
+    // latter case.
+    //
+    // The case of YYYYWww can be distinguished from YYYYWwwd by tracking ahead
+    // to either the end of the string or the first non-numeric character —
+    // since the time components all come in pairs YYYYWww#HH can be
+    // distinguished from YYYYWwwd#HH by the fact that there will always be an
+    // odd number of digits before the first non-digit character in the former
+    // case.
+    static const char date_separator = '-';
+    static const char week_indicator = 'W';
+
+    if (len == 7) {
+        return 7;
+    }
+
+    if (dtstr[4] == date_separator) {
+        // YYYY-???
+
+        if (dtstr[5] == week_indicator) {
+            // YYYY-W??
+
+            if (len < 8) {
+                return -1;
+            }
+
+            if (len > 8 && dtstr[8] == date_separator) {
+                // YYYY-Www-D (10) or YYYY-Www-HH (8)
+                if (len == 9) { return -1; }
+                if (len > 10 && is_digit(dtstr[10])) {
+                    // This is as far as we'll try to go to resolve the
+                    // ambiguity for the moment — if we have YYYY-Www-##, the
+                    // separator is either a hyphen at 8 or a number at 10.
+                    //
+                    // We'll assume it's a hyphen at 8 because it's way more
+                    // likely that someone will use a hyphen as a separator
+                    // than a number, but at this point it's really best effort
+                    // because this is an extension of the spec anyway.
+                    return 8;
+                }
+
+                return 10;
+            } else {
+                // YYYY-Www (8)
+                return 8;
+            }
+        } else {
+            // YYYY-MM-DD (10)
+            return 10;
+        }
+    } else {
+        // YYYY???
+        if (dtstr[4] == week_indicator) {
+            // YYYYWww (7) or YYYYWwwd (8)
+            size_t idx = 7;
+            for (; idx < (size_t)len; ++idx) {
+                // Keep going until we run out of digits.
+                if (!is_digit(dtstr[idx])) {
+                    break;
+                }
+            }
+
+            if (idx < 9) {
+                return idx;
+            }
+
+            if (idx % 2 == 0) {
+                // If the index of the last number is even, it's YYYYWww
+                return 7;
+            } else {
+                return 8;
+            }
+        } else {
+            // YYYYMMDD (8)
+            return 8;
+        }
+    }
 }
 
 PyObject *
@@ -476,32 +916,58 @@ datetime_fromisoformat(PyObject *dtstr)
         return NULL;
     }
 
+    // We only need to sanitize this string if the separator is a surrogate
+    // character. In the situation where the separator location is ambiguous,
+    // we don't have to sanitize it anything because that can only happen when
+    // the separator is either '-' or a number. This should mostly be a noop
+    // but it makes the reference counting easier if we still sanitize.
+    PyObject *dtstr_clean = _sanitize_isoformat_str(dtstr);
+    if (dtstr_clean == NULL) {
+        goto invalid_string_error;
+    }
+
     Py_ssize_t len;
-    const char *dt_ptr = PyUnicode_AsUTF8AndSize(dtstr, &len);
+    const char *dt_ptr = PyUnicode_AsUTF8AndSize(dtstr_clean, &len);
+
+    if (dt_ptr == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_UnicodeEncodeError)) {
+            // Encoding errors are invalid string errors at this point
+            goto invalid_string_error;
+        }
+        else {
+            goto error;
+        }
+    }
+
+    const Py_ssize_t separator_location = _find_isoformat_datetime_separator(
+            dt_ptr, len);
+
+
     const char *p = dt_ptr;
 
     int year = 0, month = 0, day = 0;
     int hour = 0, minute = 0, second = 0, microsecond = 0;
     int tzoffset = 0, tzusec = 0;
 
-    // date has a fixed length of 10
-    int rv = parse_isoformat_date(p, &year, &month, &day);
+    // date runs up to separator_location
+    int rv = parse_isoformat_date(p, separator_location, &year, &month, &day);
 
-    if (!rv && len > 10) {
+    if (!rv && len > separator_location) {
         // In UTF-8, the length of multi-byte characters is encoded in the MSB
-        if ((p[10] & 0x80) == 0) {
-            p += 11;
+        p += separator_location;
+        if ((p[0] & 0x80) == 0) {
+            p += 1;
         }
         else {
-            switch (p[10] & 0xf0) {
+            switch (p[0] & 0xf0) {
                 case 0xe0:
-                    p += 13;
+                    p += 3;
                     break;
                 case 0xf0:
-                    p += 14;
+                    p += 4;
                     break;
                 default:
-                    p += 12;
+                    p += 2;
                     break;
             }
         }
@@ -511,13 +977,12 @@ datetime_fromisoformat(PyObject *dtstr)
                                   &microsecond, &tzoffset, &tzusec);
     }
     if (rv < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %s", dt_ptr);
-        return NULL;
+        goto invalid_string_error;
     }
 
     PyObject *tzinfo = tzinfo_from_isoformat_results(rv, tzoffset, tzusec);
     if (tzinfo == NULL) {
-        return NULL;
+        goto error;
     }
 
 #if !PY_VERSION_AT_LEAST_36
@@ -541,7 +1006,16 @@ datetime_fromisoformat(PyObject *dtstr)
         PyDateTimeAPI->DateTimeType);
 
     Py_DECREF(tzinfo);
+    Py_DECREF(dtstr_clean);
     return dt;
+
+invalid_string_error:
+    PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %R", dtstr);
+
+error:
+    Py_XDECREF(dtstr_clean);
+
+    return NULL;
 }
 
 void

--- a/backports/datetime_fromisoformat/module.c
+++ b/backports/datetime_fromisoformat/module.c
@@ -5,37 +5,37 @@
 #include "timezone.h"
 
 static PyObject *
-fromisoformat_date(PyObject *self, PyObject *args)
+fromisoformat_date(PyObject *self, PyObject *dtstr)
 {
     PyObject *obj;
-    obj = date_fromisoformat(PyTuple_GetItem(args, 0));
+    obj = date_fromisoformat(dtstr);
     return obj;
 }
 
 static PyObject *
-fromisoformat_time(PyObject *self, PyObject *args)
+fromisoformat_time(PyObject *self, PyObject *dtstr)
 {
     PyObject *obj;
-    obj = time_fromisoformat(PyTuple_GetItem(args, 0));
+    obj = time_fromisoformat(dtstr);
     return obj;
 }
 
 static PyObject *
-fromisoformat_datetime(PyObject *self, PyObject *args)
+fromisoformat_datetime(PyObject *self, PyObject *dtstr)
 {
     PyObject *obj;
-    obj = datetime_fromisoformat(PyTuple_GetItem(args, 0));
+    obj = datetime_fromisoformat(dtstr);
     return obj;
 }
 
 static PyMethodDef FromISOFormatMethods[] = {
-    {"date_fromisoformat", fromisoformat_date, METH_VARARGS,
+    {"date_fromisoformat", fromisoformat_date, METH_O,
      "Return a date corresponding to a date_string in one of the formats "
      "emitted by date.isoformat()"},
-    {"time_fromisoformat", fromisoformat_time, METH_VARARGS,
+    {"time_fromisoformat", fromisoformat_time, METH_O,
      "Return a time corresponding to a date_string in one of the formats "
      "emitted by time.isoformat()"},
-    {"datetime_fromisoformat", fromisoformat_datetime, METH_VARARGS,
+    {"datetime_fromisoformat", fromisoformat_datetime, METH_O,
      "Return a datetime corresponding to a date_string in one of the formats "
      "emitted by datetime.isoformat()"},
     {NULL, NULL, 0, NULL}};

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,29 @@ from io import open
 with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
+# We want to force all warnings to be considered errors. That way we get to catch potential issues during
+# development and at PR review time.
+# But since backports.datetime_fromisoformat is a source distribution, exotic compiler configurations can cause spurious warnings that
+# would fail the installation. So we only want to treat warnings as errors during development.
+if os.environ.get("STRICT_WARNINGS", "0") == "1":
+    # We can't use `extra_compile_args`, since the cl.exe (Windows) and gcc compilers don't use the same flags.
+    # Further, there is not an easy way to tell which compiler is being used.
+    # Instead we rely on each compiler looking at their appropriate environment variable.
+
+    # GCC/Clang
+    try:
+        _ = os.environ["CFLAGS"]
+    except KeyError:
+        os.environ["CFLAGS"] = ""
+    os.environ["CFLAGS"] += " -Werror"
+
+    # cl.exe
+    try:
+        _ = os.environ["_CL_"]
+    except KeyError:
+        os.environ["_CL_"] = ""
+    os.environ["_CL_"] += " /WX"
+
 VERSION = "2.0.0"
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
 import os
 
 from setuptools import setup, Extension
-# workaround for open() with encoding='' python2/3 compability
+# workaround for open() with encoding='' python2/3 compatibility
 from io import open
 
 with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
-VERSION = "1.0.0"
+VERSION = "2.0.0"
 
 setup(
     name="backports-datetime-fromisoformat",
     version=VERSION,
-    description="Backport of Python 3.7's datetime.fromisoformat",
+    description="Backport of Python 3.11's datetime.fromisoformat",
     long_description=long_description,
     license="MIT",
     author="Michael Overmeyer",
@@ -40,6 +40,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,9 @@
 import copy
+import io
+import itertools
 import pickle
 import pytz
+import re
 import sys
 import unittest
 
@@ -37,14 +40,53 @@ class TestsFromCPython(unittest.TestCase):
                 dt_str = dt.isoformat()
                 with self.subTest(dt_str=dt_str):
                     dt_rt = date_cls.fromisoformat(dt.isoformat())
+                    self.assertEqual(dt, dt_rt)
 
                     self.assertEqual(dt, dt_rt)
                     self.assertIsInstance(dt_rt, date_cls)
+
+    def test_fromisoformat_examples(self):
+        examples = [
+            ('00010101', (1, 1, 1)),
+            ('20000101', (2000, 1, 1)),
+            ('20250102', (2025, 1, 2)),
+            ('99991231', (9999, 12, 31)),
+            ('0001-01-01', (1, 1, 1)),
+            ('2000-01-01', (2000, 1, 1)),
+            ('2025-01-02', (2025, 1, 2)),
+            ('9999-12-31', (9999, 12, 31)),
+            ('2025W01', (2024, 12, 30)),
+            ('2025-W01', (2024, 12, 30)),
+            ('2025W014', (2025, 1, 2)),
+            ('2025-W01-4', (2025, 1, 2)),
+            ('2026W01', (2025, 12, 29)),
+            ('2026-W01', (2025, 12, 29)),
+            ('2026W013', (2025, 12, 31)),
+            ('2026-W01-3', (2025, 12, 31)),
+            ('2022W52', (2022, 12, 26)),
+            ('2022-W52', (2022, 12, 26)),
+            ('2022W527', (2023, 1, 1)),
+            ('2022-W52-7', (2023, 1, 1)),
+            ('2015W534', (2015, 12, 31)),      # Has week 53
+            ('2015-W53-4', (2015, 12, 31)),    # Has week 53
+            ('2015-W53-5', (2016, 1, 1)),
+            ('2020W531', (2020, 12, 28)),      # Leap year
+            ('2020-W53-1', (2020, 12, 28)),    # Leap year
+            ('2020-W53-6', (2021, 1, 2)),
+        ]
+
+        for date_cls in [datetime, date]:
+            for input_str, expected_values in examples:
+                expected = date_cls(*expected_values)
+                with self.subTest(input_str=input_str):
+                    actual = date_cls.fromisoformat(input_str)
+                    self.assertEqual(actual, expected)
 
     def test_fromisoformat_fails(self):
         # Test that fromisoformat() fails on invalid values
         bad_strs = [
             '',                 # Empty string
+            '\ud800',           # bpo-34454: Surrogate code point
             '009-03-04',        # Not 10 characters
             '123456789',        # Not a date
             '200a-12-04',       # Invalid character in year
@@ -52,7 +94,9 @@ class TestsFromCPython(unittest.TestCase):
             '2009-12-0a',       # Invalid character in day
             '2009-01-32',       # Invalid day
             '2009-02-29',       # Invalid leap day
-            '20090228',         # Valid ISO8601 output not from isoformat()
+            '2019-W53-1',       # No week 53 in 2019
+            '2020-W54-1',       # No week 54
+            '2009\ud80002\ud80028',     # Separators are surrogate codepoints
         ]
 
         for bad_str in bad_strs:
@@ -64,8 +108,6 @@ class TestsFromCPython(unittest.TestCase):
 
     def test_fromisoformat_fails_typeerror(self):
         # Test that fromisoformat fails when passed the wrong type
-        import io
-
         bad_types = [b'2009-03-01', None, io.StringIO('2009-03-01')]
         for bad_type in bad_types:
             with self.assertRaises(TypeError, msg="Did not fail on '{0}'".format(bad_type)):
@@ -109,12 +151,11 @@ class TestsFromCPython(unittest.TestCase):
                     dt_rt = datetime.fromisoformat(dtstr)
                     self.assertEqual(dt, dt_rt)
 
-    def test_fromisoformat_timezone(self):
+    def test_datetime_fromisoformat_timezone(self):
         base_dt = datetime(2014, 12, 30, 12, 30, 45, 217456)
 
         tzoffsets = [
-            timedelta(hours=5),
-            timedelta(hours=2),
+            timedelta(hours=5), timedelta(hours=2),
             timedelta(hours=6, minutes=27),
 
             # Our timezone implementation doesn't handle sub-minute offsets.
@@ -142,7 +183,8 @@ class TestsFromCPython(unittest.TestCase):
             ' ', 'T', '\u007f',     # 1-bit widths
             '\u0080', 'ʁ',          # 2-bit widths
             'ᛇ', '時',               # 3-bit widths
-            '🐍'                     # 4-bit widths
+            '🐍',                    # 4-bit widths
+            '\ud800',               # bpo-34454: Surrogate code point
         ]
 
         for sep in separators:
@@ -165,7 +207,7 @@ class TestsFromCPython(unittest.TestCase):
                 self.assertEqual(dt, dt_rt)
 
     def test_fromisoformat_timespecs(self):
-        if sys.version_info >= (3, 6):
+        if sys.version_info >= (3, 6): # timespec parameter was added in Python 3.6
             datetime_bases = [
                 (2009, 12, 4, 8, 17, 45, 123456),
                 (2009, 12, 4, 8, 17, 45, 0)]
@@ -175,7 +217,8 @@ class TestsFromCPython(unittest.TestCase):
                        pytz.FixedOffset(2 * 60),
                        pytz.FixedOffset(6 * 60 + 27)]
 
-            timespecs = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds']
+            timespecs = ['hours', 'minutes', 'seconds',
+                         'milliseconds', 'microseconds']
 
             for ip, ts in enumerate(timespecs):
                 for tzi in tzinfos:
@@ -190,10 +233,146 @@ class TestsFromCPython(unittest.TestCase):
                             dt_rt = datetime.fromisoformat(dtstr)
                             self.assertEqual(dt, dt_rt)
 
+    def test_fromisoformat_datetime_examples(self):
+        UTC = pytz.utc
+        BST = pytz.FixedOffset(1 * 60)
+        EST = pytz.FixedOffset(-5 * 60)
+        EDT = pytz.FixedOffset(-4 * 60)
+        examples = [
+            ('2025-01-02', datetime(2025, 1, 2, 0, 0)),
+            ('2025-01-02T03', datetime(2025, 1, 2, 3, 0)),
+            ('2025-01-02T03:04', datetime(2025, 1, 2, 3, 4)),
+            ('2025-01-02T0304', datetime(2025, 1, 2, 3, 4)),
+            ('2025-01-02T03:04:05', datetime(2025, 1, 2, 3, 4, 5)),
+            ('2025-01-02T030405', datetime(2025, 1, 2, 3, 4, 5)),
+            ('2025-01-02T03:04:05.6',
+             datetime(2025, 1, 2, 3, 4, 5, 600000)),
+            ('2025-01-02T03:04:05,6',
+             datetime(2025, 1, 2, 3, 4, 5, 600000)),
+            ('2025-01-02T03:04:05.678',
+             datetime(2025, 1, 2, 3, 4, 5, 678000)),
+            ('2025-01-02T03:04:05.678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2025-01-02T03:04:05,678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2025-01-02T030405.678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2025-01-02T030405,678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2025-01-02T03:04:05.6789010',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2009-04-19T03:15:45.2345',
+             datetime(2009, 4, 19, 3, 15, 45, 234500)),
+            ('2009-04-19T03:15:45.1234567',
+             datetime(2009, 4, 19, 3, 15, 45, 123456)),
+            ('2025-01-02T03:04:05,678',
+             datetime(2025, 1, 2, 3, 4, 5, 678000)),
+            ('20250102', datetime(2025, 1, 2, 0, 0)),
+            ('20250102T03', datetime(2025, 1, 2, 3, 0)),
+            ('20250102T03:04', datetime(2025, 1, 2, 3, 4)),
+            ('20250102T03:04:05', datetime(2025, 1, 2, 3, 4, 5)),
+            ('20250102T030405', datetime(2025, 1, 2, 3, 4, 5)),
+            ('20250102T03:04:05.6',
+             datetime(2025, 1, 2, 3, 4, 5, 600000)),
+            ('20250102T03:04:05,6',
+             datetime(2025, 1, 2, 3, 4, 5, 600000)),
+            ('20250102T03:04:05.678',
+             datetime(2025, 1, 2, 3, 4, 5, 678000)),
+            ('20250102T03:04:05,678',
+             datetime(2025, 1, 2, 3, 4, 5, 678000)),
+            ('20250102T03:04:05.678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('20250102T030405.678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('20250102T030405,678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('20250102T030405.6789010',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2022W01', datetime(2022, 1, 3)),
+            ('2022W52520', datetime(2022, 12, 26, 20, 0)),
+            ('2022W527520', datetime(2023, 1, 1, 20, 0)),
+            ('2026W01516', datetime(2025, 12, 29, 16, 0)),
+            ('2026W013516', datetime(2025, 12, 31, 16, 0)),
+            ('2025W01503', datetime(2024, 12, 30, 3, 0)),
+            ('2025W014503', datetime(2025, 1, 2, 3, 0)),
+            ('2025W01512', datetime(2024, 12, 30, 12, 0)),
+            ('2025W014512', datetime(2025, 1, 2, 12, 0)),
+            ('2025W014T121431', datetime(2025, 1, 2, 12, 14, 31)),
+            ('2026W013T162100', datetime(2025, 12, 31, 16, 21)),
+            ('2026W013 162100', datetime(2025, 12, 31, 16, 21)),
+            ('2022W527T202159', datetime(2023, 1, 1, 20, 21, 59)),
+            ('2022W527 202159', datetime(2023, 1, 1, 20, 21, 59)),
+            ('2025W014 121431', datetime(2025, 1, 2, 12, 14, 31)),
+            ('2025W014T030405', datetime(2025, 1, 2, 3, 4, 5)),
+            ('2025W014 030405', datetime(2025, 1, 2, 3, 4, 5)),
+            ('2020-W53-6T03:04:05', datetime(2021, 1, 2, 3, 4, 5)),
+            ('2020W537 03:04:05', datetime(2021, 1, 3, 3, 4, 5)),
+            ('2025-W01-4T03:04:05', datetime(2025, 1, 2, 3, 4, 5)),
+            ('2025-W01-4T03:04:05.678901',
+             datetime(2025, 1, 2, 3, 4, 5, 678901)),
+            ('2025-W01-4T12:14:31', datetime(2025, 1, 2, 12, 14, 31)),
+            ('2025-W01-4T12:14:31.012345',
+             datetime(2025, 1, 2, 12, 14, 31, 12345)),
+            ('2026-W01-3T16:21:00', datetime(2025, 12, 31, 16, 21)),
+            ('2026-W01-3T16:21:00.000000', datetime(2025, 12, 31, 16, 21)),
+            ('2022-W52-7T20:21:59',
+             datetime(2023, 1, 1, 20, 21, 59)),
+            ('2022-W52-7T20:21:59.999999',
+             datetime(2023, 1, 1, 20, 21, 59, 999999)),
+            ('2025-W01003+00',
+             datetime(2024, 12, 30, 3, 0, tzinfo=UTC)),
+            ('2025-01-02T03:04:05+00',
+             datetime(2025, 1, 2, 3, 4, 5, tzinfo=UTC)),
+            ('2025-01-02T03:04:05Z',
+             datetime(2025, 1, 2, 3, 4, 5, tzinfo=UTC)),
+            ('2025-01-02003:04:05,6+00:00:00.00',
+             datetime(2025, 1, 2, 3, 4, 5, 600000, tzinfo=UTC)),
+            ('2000-01-01T00+21',
+             datetime(2000, 1, 1, 0, 0, tzinfo=pytz.FixedOffset(21 * 60))),
+            ('2025-01-02T03:05:06+0300',
+             datetime(2025, 1, 2, 3, 5, 6,
+                           tzinfo=pytz.FixedOffset(3 * 60))),
+            ('2025-01-02T03:05:06-0300',
+             datetime(2025, 1, 2, 3, 5, 6,
+                           tzinfo=pytz.FixedOffset(-3 * 60))),
+            ('2025-01-02T03:04:05+0000',
+             datetime(2025, 1, 2, 3, 4, 5, tzinfo=UTC)),
+            ('2025-01-02T03:05:06+03',
+             datetime(2025, 1, 2, 3, 5, 6,
+                           tzinfo=pytz.FixedOffset(3 * 60))),
+            ('2025-01-02T03:05:06-03',
+             datetime(2025, 1, 2, 3, 5, 6,
+                           tzinfo=pytz.FixedOffset(-3 * 60))),
+            ('2020-01-01T03:05:07.123457-05:00',
+             datetime(2020, 1, 1, 3, 5, 7, 123457, tzinfo=EST)),
+            ('2020-01-01T03:05:07.123457-0500',
+             datetime(2020, 1, 1, 3, 5, 7, 123457, tzinfo=EST)),
+            ('2020-06-01T04:05:06.111111-04:00',
+             datetime(2020, 6, 1, 4, 5, 6, 111111, tzinfo=EDT)),
+            ('2020-06-01T04:05:06.111111-0400',
+             datetime(2020, 6, 1, 4, 5, 6, 111111, tzinfo=EDT)),
+            ('2021-10-31T01:30:00.000000+01:00',
+             datetime(2021, 10, 31, 1, 30, tzinfo=BST)),
+            ('2021-10-31T01:30:00.000000+0100',
+             datetime(2021, 10, 31, 1, 30, tzinfo=BST)),
+            ('2025-01-02T03:04:05,6+000000.00',
+             datetime(2025, 1, 2, 3, 4, 5, 600000, tzinfo=UTC)),
+            # Our timezone implementation doesn't handle sub-minute offsets.
+            # ('2025-01-02T03:04:05,678+00:00:10',
+            #  datetime(2025, 1, 2, 3, 4, 5, 678000,
+            #                tzinfo=timezone(timedelta(seconds=10)))),
+        ]
+
+        for input_str, expected in examples:
+            with self.subTest(input_str=input_str):
+                actual = datetime.fromisoformat(input_str)
+                self.assertEqual(actual, expected)
+
     def test_fromisoformat_fails_datetime(self):
         # Test that fromisoformat() fails on invalid values
         bad_strs = [
             '',                             # Empty string
+            '\ud800',                       # bpo-34454: Surrogate code point
             '2009.04-19T03',                # Wrong first separator
             '2009-04.19T03',                # Wrong second separator
             '2009-04-19T0a',                # Invalid hours
@@ -202,22 +381,19 @@ class TestsFromCPython(unittest.TestCase):
             '2009-04-19T03;15:45',          # Bad first time separator
             '2009-04-19T03:15;45',          # Bad second time separator
             '2009-04-19T03:15:4500:00',     # Bad time zone separator
-            '2009-04-19T03:15:45.2345',     # Too many digits for milliseconds
-            '2009-04-19T03:15:45.1234567',  # Too many digits for microseconds
-
-            # Our timezone implementation doesn't mind > 24h offsets
-            # '2009-04-19T03:15:45.123456+24:30',    # Invalid time zone offset
-            # '2009-04-19T03:15:45.123456-24:30',    # Invalid negative offset
-
+            '2009-04-19T03:15:45.123456+24:30',    # Invalid time zone offset
+            '2009-04-19T03:15:45.123456-24:30',    # Invalid negative offset
             '2009-04-10ᛇᛇᛇᛇᛇ12:15',         # Too many unicode separators
+            '2009-04\ud80010T12:15',        # Surrogate char in date
+            '2009-04-10T12\ud80015',        # Surrogate char in time
             '2009-04-19T1',                 # Incomplete hours
             '2009-04-19T12:3',              # Incomplete minutes
             '2009-04-19T12:30:4',           # Incomplete seconds
             '2009-04-19T12:',               # Ends with time separator
             '2009-04-19T12:30:',            # Ends with time separator
             '2009-04-19T12:30:45.',         # Ends with time separator
-            '2009-04-19T12:30:45.123456+',  # Ends with timzone separator
-            '2009-04-19T12:30:45.123456-',  # Ends with timzone separator
+            '2009-04-19T12:30:45.123456+',  # Ends with timezone separator
+            '2009-04-19T12:30:45.123456-',  # Ends with timezone separator
             '2009-04-19T12:30:45.123456-05:00a',    # Extra text
             '2009-04-19T12:30:45.123-05:00a',       # Extra text
             '2009-04-19T12:30:45-05:00a',           # Extra text
@@ -228,6 +404,14 @@ class TestsFromCPython(unittest.TestCase):
                 with self.assertRaises(ValueError, msg="Did not fail on '{0}'".format(bad_str)):
                     datetime.fromisoformat(bad_str)
 
+    def test_datetime_fromisoformat_fails_surrogate(self):
+        # Test that when fromisoformat() fails with a surrogate character as
+        # the separator, the error message contains the original string
+        dtstr = "2018-01-03\ud80001:0113"
+
+        with self.assertRaisesRegex(ValueError, re.escape(repr(dtstr))):
+            datetime.fromisoformat(dtstr)
+
     # Our timezone implementation doesn't have a concept of UTC being special
     # def test_fromisoformat_utc(self):
     #     dt_str = '2014-04-19T13:21:13+00:00'
@@ -235,12 +419,197 @@ class TestsFromCPython(unittest.TestCase):
     #     self.assertIs(dt.tzinfo, pytz.utc)
 
     def test_time_fromisoformat(self):
-        tsc = time(12, 14, 45, 203745, tzinfo=pytz.utc)
-        tsc_rt = time.fromisoformat(tsc.isoformat())
+        time_examples = [
+            (0, 0, 0, 0),
+            (23, 59, 59, 999999),
+        ]
 
-        self.assertEqual(tsc, tsc_rt)
-        self.assertIsInstance(tsc_rt, time)
+        hh = (9, 12, 20)
+        mm = (5, 30)
+        ss = (4, 45)
+        usec = (0, 245000, 678901)
 
+        time_examples += list(itertools.product(hh, mm, ss, usec))
+
+        tzinfos = [None, pytz.utc,
+                       pytz.FixedOffset(2 * 60),
+                       pytz.FixedOffset(6 * 60 + 27)]
+
+        for ttup in time_examples:
+            for tzi in tzinfos:
+                t = time(*ttup, tzinfo=tzi)
+                tstr = t.isoformat()
+
+                with self.subTest(tstr=tstr):
+                    t_rt = time.fromisoformat(tstr)
+                    self.assertEqual(t, t_rt)
+
+    def test_time_fromisoformat_timezone(self):
+        base_time = time(12, 30, 45, 217456)
+
+        tzoffsets = [
+            5 * 60,
+            2 * 60,
+            (6 * 60) + 27,
+
+            # Our timezone implementation doesn't handle sub-minute offsets.
+            # timedelta(hours=12, minutes=32, seconds=30),
+            # timedelta(hours=2, minutes=4, seconds=9, microseconds=123456)
+        ]
+
+        tzoffsets += [-1 * offset for offset in tzoffsets]
+
+        tzinfos = [None, pytz.utc,
+                   pytz.FixedOffset(0)]
+
+        tzinfos += [pytz.FixedOffset(offset) for offset in tzoffsets]
+
+        for tzi in tzinfos:
+            t = base_time.replace(tzinfo=tzi)
+            tstr = t.isoformat()
+
+            with self.subTest(tstr=tstr):
+                t_rt = time.fromisoformat(tstr)
+                assert t == t_rt, t_rt
+
+    def test_time_fromisoformat_timespecs(self):
+        if sys.version_info >= (3, 6): # timespec parameter was added in Python 3.6
+            time_bases = [
+                (8, 17, 45, 123456),
+                (8, 17, 45, 0)
+            ]
+
+            tzinfos = [None, pytz.utc,
+                    pytz.FixedOffset(-5 * 60),
+                    pytz.FixedOffset(2 * 60),
+                    pytz.FixedOffset((6 * 60) +27)]
+
+            timespecs = ['hours', 'minutes', 'seconds',
+                        'milliseconds', 'microseconds']
+
+            for ip, ts in enumerate(timespecs):
+                for tzi in tzinfos:
+                    for t_tuple in time_bases:
+                        if ts == 'milliseconds':
+                            new_microseconds = 1000 * (t_tuple[-1] // 1000)
+                            t_tuple = t_tuple[0:-1] + (new_microseconds,)
+
+                        t = time(*(t_tuple[0:(1 + ip)]), tzinfo=tzi)
+                        tstr = t.isoformat(timespec=ts)
+                        with self.subTest(tstr=tstr):
+                            t_rt = time.fromisoformat(tstr)
+                            self.assertEqual(t, t_rt)
+
+    def test_time_fromisoformat_fractions(self):
+        strs = [
+            ('12:30:45.1', (12, 30, 45, 100000)),
+            ('12:30:45.12', (12, 30, 45, 120000)),
+            ('12:30:45.123', (12, 30, 45, 123000)),
+            ('12:30:45.1234', (12, 30, 45, 123400)),
+            ('12:30:45.12345', (12, 30, 45, 123450)),
+            ('12:30:45.123456', (12, 30, 45, 123456)),
+            ('12:30:45.1234567', (12, 30, 45, 123456)),
+            ('12:30:45.12345678', (12, 30, 45, 123456)),
+        ]
+
+        for time_str, time_comps in strs:
+            expected = time(*time_comps)
+            actual = time.fromisoformat(time_str)
+
+            self.assertEqual(actual, expected)
+
+    def test_fromisoformat_time_examples(self):
+        examples = [
+            ('0000', time(0, 0)),
+            ('00:00', time(0, 0)),
+            ('000000', time(0, 0)),
+            ('00:00:00', time(0, 0)),
+            ('000000.0', time(0, 0)),
+            ('00:00:00.0', time(0, 0)),
+            ('000000.000', time(0, 0)),
+            ('00:00:00.000', time(0, 0)),
+            ('000000.000000', time(0, 0)),
+            ('00:00:00.000000', time(0, 0)),
+            ('1200', time(12, 0)),
+            ('12:00', time(12, 0)),
+            ('120000', time(12, 0)),
+            ('12:00:00', time(12, 0)),
+            ('120000.0', time(12, 0)),
+            ('12:00:00.0', time(12, 0)),
+            ('120000.000', time(12, 0)),
+            ('12:00:00.000', time(12, 0)),
+            ('120000.000000', time(12, 0)),
+            ('12:00:00.000000', time(12, 0)),
+            ('2359', time(23, 59)),
+            ('23:59', time(23, 59)),
+            ('235959', time(23, 59, 59)),
+            ('23:59:59', time(23, 59, 59)),
+            ('235959.9', time(23, 59, 59, 900000)),
+            ('23:59:59.9', time(23, 59, 59, 900000)),
+            ('235959.999', time(23, 59, 59, 999000)),
+            ('23:59:59.999', time(23, 59, 59, 999000)),
+            ('235959.999999', time(23, 59, 59, 999999)),
+            ('23:59:59.999999', time(23, 59, 59, 999999)),
+            ('00:00:00Z', time(0, 0, tzinfo=pytz.utc)),
+            ('12:00:00+0000', time(12, 0, tzinfo=pytz.utc)),
+            ('12:00:00+00:00', time(12, 0, tzinfo=pytz.utc)),
+            ('00:00:00+05',
+             time(0, 0, tzinfo=pytz.FixedOffset(5 * 60))),
+            ('00:00:00+05:30',
+             time(0, 0, tzinfo=pytz.FixedOffset((5 * 60) + 30))),
+            ('12:00:00-05:00',
+             time(12, 0, tzinfo=pytz.FixedOffset(-5 * 60))),
+            ('12:00:00-0500',
+             time(12, 0, tzinfo=pytz.FixedOffset(-5 * 60))),
+            # Our timezone implementation doesn't handle sub-minute offsets.
+            # ('00:00:00,000-23:59:59.999999',
+            #  time(0, 0, tzinfo=timezone(-timedelta(hours=23, minutes=59, seconds=59, microseconds=999999)))),
+        ]
+
+        for input_str, expected in examples:
+            with self.subTest(input_str=input_str):
+                actual = time.fromisoformat(input_str)
+                self.assertEqual(actual, expected)
+
+    def test_time_fromisoformat_fails(self):
+        bad_strs = [
+            '',                         # Empty string
+            '12\ud80000',               # Invalid separator - surrogate char
+            '12:',                      # Ends on a separator
+            '12:30:',                   # Ends on a separator
+            '12:30:15.',                # Ends on a separator
+            '1',                        # Incomplete hours
+            '12:3',                     # Incomplete minutes
+            '12:30:1',                  # Incomplete seconds
+            '1a:30:45.334034',          # Invalid character in hours
+            '12:a0:45.334034',          # Invalid character in minutes
+            '12:30:a5.334034',          # Invalid character in seconds
+            '12:30:45.123456+24:30',    # Invalid time zone offset
+            '12:30:45.123456-24:30',    # Invalid negative offset
+            '12：30：45',                 # Uses full-width unicode colons
+            '12:30:45.123456a',         # Non-numeric data after 6 components
+            '12:30:45.123456789a',      # Non-numeric data after 9 components
+            '12:30:45․123456',          # Uses \u2024 in place of decimal point
+            '12:30:45a',                # Extra at tend of basic time
+            '12:30:45.123a',            # Extra at end of millisecond time
+            '12:30:45.123456a',         # Extra at end of microsecond time
+            '12:30:45.123456-',         # Extra at end of microsecond time
+            '12:30:45.123456+',         # Extra at end of microsecond time
+            '12:30:45.123456+12:00:30a',    # Extra at end of full time
+        ]
+
+        for bad_str in bad_strs:
+            with self.subTest(bad_str=bad_str):
+                with self.assertRaises(ValueError, msg="Did not fail on '{0}'".format(bad_str)):
+                    time.fromisoformat(bad_str)
+
+    def test_time_fromisoformat_fails_typeerror(self):
+        # Test the fromisoformat fails when passed the wrong type
+        bad_types = [b'12:30:45', None, io.StringIO('12:30:45')]
+
+        for bad_type in bad_types:
+            with self.assertRaises(TypeError, msg="Did not fail on '{0}'".format(bad_type)):
+                time.fromisoformat(bad_type)
 
 class TestCopy(unittest.TestCase):
     def test_basic_pickle_and_copy(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = py311,py310,py39,py38,py37,py36,py35,py34
 
 [testenv]
+setenv =
+    STRICT_WARNINGS = 1
 deps=
     pytz
     nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,py38,py39,py310,py311
+envlist = py311,py310,py39,py38,py37,py36,py35,py34
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py34,py35,py36,py37,py38,py39,py310,py311
 
 [testenv]
 deps=


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #21 

Python 3.7 introduced the `fromisoformat` methods, but they were just inverses of their counterpart `isoformat` methods. They could not parse arbitrary ISO timestamps, just the ones that `isoformat` could produce.

Python 3.11 expanded the formats that the `fromisoformat` methods could parse, adding support for most of the ISO 8601 spec.

### What approach did you choose and why?

* Refreshed the backports using cPython 3.11's [code](https://github.com/python/cpython/blob/main/Modules/_datetimemodule.c) and [tests](https://github.com/python/cpython/blob/main/Lib/test/datetimetester.py). 
* Extended the monkey-patching to apply to all Python 3 versions < 3.10.
* Add bounds checking for out-of-range time zone offsets (> 1440 minutes), to match the behaviour of cPython
* Switched from `METH_VARARGS` -> `METH_O` method descriptions for much faster calls
  * Similar to https://github.com/closeio/ciso8601/pull/130
* Updated the CI to be able to run again, and also to fail on compiler warnings.

### What should reviewers focus on?

...

### The impact of these changes

Now you can use the backports to parse the same wide portion of ISO 8601 specification in older Python versions.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...
