### PR TITLE
Modernize builds and testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install lint tools
         run: 'pip install Pygments restructuredtext-lint'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Run tests
         run: python setup.py test
@@ -24,14 +24,14 @@ jobs:
         run: python setup.py sdist
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.4", "3.5"]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,25 +50,3 @@ jobs:
 
       - name: Run tests
         run: tox --skip-missing-interpreters=true
-
-
-  build-even-older:
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: ["3.4", "3.5"]
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      # tox doesn't support these versions of Python anymore
-      - name: Install tox
-        run: pip install 'tox < 4'
-
-      - name: Run tests
-        run: tox --skip-missing-interpreters=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -24,10 +24,35 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install tox
+        run: pip install tox
+
       - name: Run tests
-        run: STRICT_WARNINGS=1 python setup.py test
+        run: tox
 
   build-old:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.6"]
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # tox doesn't support these versions of Python anymore
+      - name: Install tox
+        run: pip install 'tox < 4'
+
+      - name: Run tests
+        run: tox --skip-missing-interpreters=true
+
+
+  build-even-older:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -41,10 +66,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Requires explicit pytz installation
-      - run: pip install pytz
-
-      - run: pip install pytz
+      # tox doesn't support these versions of Python anymore
+      - name: Install tox
+        run: pip install 'tox < 4'
 
       - name: Run tests
-        run: STRICT_WARNINGS=1 python setup.py test
+        run: tox --skip-missing-interpreters=true

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ backports.datetime_fromisoformat
     :target: https://github.com/movermeyer/backports.datetime_fromisoformat/actions/workflows/test.yml
 
 A backport of Python 3.11's ``datetime.fromisoformat`` methods to earlier versions of Python 3.
-Tested against Python 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
+Tested against Python 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 
 Current Status
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "backports-datetime-fromisoformat"
+version = "2.0.0"
+authors = [
+  { name="Michael Overmeyer", email="backports@movermeyer.com" },
+]
+description = "Backport of Python 3.11's datetime.fromisoformat"
+readme = "README.rst"
+requires-python = ">3"
+license = {file = "LICENSE"}
+classifiers = [
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+]
+
+[project.urls]
+Homepage = "https://github.com/movermeyer/backports.datetime_fromisoformat"
+Documentation = "https://github.com/movermeyer/backports.datetime_fromisoformat"
+Repository = "https://github.com/movermeyer/backports.datetime_fromisoformat"
+"Bug Tracker" = "https://github.com/movermeyer/backports.datetime_fromisoformat/issues"
+Changelog = "https://github.com/movermeyer/backports.datetime_fromisoformat/CHANGELOG.md"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 import os
 
 from setuptools import setup, Extension
-# workaround for open() with encoding='' python2/3 compatibility
-from io import open
-
-with open('README.rst', encoding='utf-8') as file:
-    long_description = file.read()
 
 # We want to force all warnings to be considered errors. That way we get to catch potential issues during
 # development and at PR review time.
@@ -30,18 +25,7 @@ if os.environ.get("STRICT_WARNINGS", "0") == "1":
         os.environ["_CL_"] = ""
     os.environ["_CL_"] += " /WX"
 
-VERSION = "2.0.0"
-
 setup(
-    name="backports-datetime-fromisoformat",
-    version=VERSION,
-    description="Backport of Python 3.11's datetime.fromisoformat",
-    long_description=long_description,
-    license="MIT",
-    author="Michael Overmeyer",
-    author_email="backports@movermeyer.com",
-    url="https://github.com/movermeyer/backports.datetime_fromisoformat",
-
     packages=["backports", "backports.datetime_fromisoformat"],
 
     ext_modules=[Extension("backports._datetime_fromisoformat", [
@@ -49,24 +33,4 @@ setup(
         os.path.join("backports", "datetime_fromisoformat", "_datetimemodule.c"),
         os.path.join("backports", "datetime_fromisoformat", "timezone.c")
     ])],
-
-    test_suite='tests',
-    tests_require=[
-        'pytz'
-    ],
-    classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
 )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -626,6 +626,5 @@ class TestCopy(unittest.TestCase):
         dt3 = copy.deepcopy(dt)
         self.assertEqual(dt, dt3)
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 envlist = py311,py310,py39,py38,py37,py36,py35,py34
 
 [testenv]
+package = sdist
 setenv =
     STRICT_WARNINGS = 1
 deps=
+    pytest
     pytz
-    nose
-commands=nosetests
+commands = pytest tests


### PR DESCRIPTION
### What are you trying to accomplish?

Change to PEP 517-compatible testing and builds. Generally modernize, in the direction of solving #26. 

### What approach did you choose and why?

* Pulled most stuff from `setup.py` into `pyproject.toml`
* Bumped versions in all GitHub Actions
* Added Dependabot to notify of new GitHub Action version bumps
* Switched to `pytest` as the test runner (it felt easier)
* Switched to calling `tox` instead of the deprecated `python setup.py test`
* Dropped Python 3.4/3.5 from CI (see commit message for details)

### What should reviewers focus on?

🤷‍♂️

### The impact of these changes

There should be no impact on end users. Internal cleanup.