### PR TITLE
Remove Python v2 guards

### DIFF
--- a/backports/datetime_fromisoformat/module.c
+++ b/backports/datetime_fromisoformat/module.c
@@ -40,7 +40,6 @@ static PyMethodDef FromISOFormatMethods[] = {
      "emitted by datetime.isoformat()"},
     {NULL, NULL, 0, NULL}};
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_datetime_fromisoformat",
@@ -52,32 +51,16 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL,
 };
-#endif
 
 PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
 PyInit__datetime_fromisoformat(void)
-#else
-init_datetime_fromisoformat(void)
-#endif
 {
-#if PY_MAJOR_VERSION >= 3
     PyObject *module = PyModule_Create(&moduledef);
-#else
-    (void)Py_InitModule("_datetime_fromisoformat", FromISOFormatMethods);
-#endif
     PyDateTime_IMPORT;
 
-#if PY_MAJOR_VERSION >= 3
     if (initialize_timezone_code(module) < 0)
         return NULL;
-#else
-    initialize_timezone_code(module);
-#endif
 
     initialize_datetime_code();
-
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Originally, I wasn't sure whether I'd ever support Python v2 in this library (#2). Now I'm sure that I'm not going to, so I've removed the existing guards. 

### What approach did you choose and why?

Removed the `PY_MAJOR_VERSION` guards in `module.c`
I didn't remove the guards in `_datetimemodule.c` nor `timezone.c` since those are effectively vendored/shared with `ciso8601`, so keeping the guards in makes it easier to keep those in sync.

### What should reviewers focus on?

That I didn't mess up the indentation in the process.

### The impact of these changes

Less code, less problems. No externally visible changes.