### PR TITLE
Add support for aarch64 wheel builds

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,9 @@ name: Lint
 # events but only for the main branch
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   lint:
@@ -19,10 +19,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: "3.12"
 
       - name: Install lint tools
-        run: 'pip install Pygments restructuredtext-lint'
+        run: "pip install Pygments restructuredtext-lint"
 
       - name: Lint docs
         run: rst-lint --encoding=utf-8 README.rst

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,12 +112,14 @@ jobs:
         run: |
           awk '{sub(/^version = ".*?"$/,"version = \"${{ env.version_to_use }}\""); print}' pyproject.toml > temp && mv temp pyproject.toml
 
+      - name: Set up QEMU # Needed to build aarch64 wheels, https://cibuildwheel.pypa.io/en/stable/faq/#emulation
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
-        env:
-          CIBW_BUILD: "cp37* cp38* cp39* cp310* pp37* pp38* pp39* pp310*"
-          CIBW_SKIP: "pp*-macosx* *-win32 *-manylinux_i686"
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
       - uses: actions/upload-artifact@v4
         with:
@@ -149,10 +151,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
-        env:
-          CIBW_BUILD: "cp37* cp38* cp39* cp310* pp37* pp38* pp39* pp310*"
-          CIBW_SKIP: "pp*-macosx* pp*-win* *-win32 *-manylinux_i686"
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
       - uses: actions/upload-artifact@v4
         with:
@@ -204,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: test_pypi
     permissions:
-      id-token: write  # Required for "trusted publishing"
+      id-token: write # Required for "trusted publishing"
 
     steps:
       - uses: actions/download-artifact@v4
@@ -305,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production_pypi
     permissions:
-      id-token: write  # Required for "trusted publishing"
+      id-token: write # Required for "trusted publishing"
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,6 +227,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.10.1
         with:
           repository-url: https://test.pypi.org/legacy/
+          attestations: true
 
   pre_publish_sanity_check:
     needs: [publish_to_test_pypi]
@@ -326,3 +327,5 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.10.1
+        with:
+          attestations: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist_${{ matrix.os }}
           path: |
             ./wheelhouse/*.whl
             !./wheelhouse/UNKNOWN*.whl
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist_windows
           path: |
             ./wheelhouse/*.whl
             !./wheelhouse/UNKNOWN*.whl
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist_source
           path: dist/*.tar.gz
 
   publish_to_test_pypi:
@@ -220,7 +220,8 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: dist
+          pattern: dist_*
+          merge-multiple: true
           path: dist/
 
       - name: Publish package to TestPyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - [2.x.x](#2xx)
   - [Migration from 1.x.x](#migration-from-1xx)
+  - [Unreleased](#unreleased)
   - [Version 2.0.1](#version-201)
   - [Version 2.0.0](#version-200)
 - [1.x.x](#1xx)
@@ -19,6 +20,10 @@
 No migration is needed.
 
 However, starting in version 2, `backports.datetime_fromisoformat` will apply its changes to Python < 3.11, whereas v1 only applied changes to Python < 3.7. If you happened to be using `backports.datetime_fromisoformat` v1 on Python 3.7 through Python 3.10 and then upgrade to v2, it will patch the `fromisoformat` methods, whereas in v1 it did not. The `fromisoformat` methods will be able to parse timestamps from a wider portion of the ISO 8601 specification. This is unlikely to be a problem, but for completeness it is mentioned here.
+
+## Unreleased
+
+* Add support for aarch64 wheels
 
 ## Version 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [2.x.x](#2xx)
   - [Migration from 1.x.x](#migration-from-1xx)
   - [Unreleased](#unreleased)
+  - [Version 2.0.2](#version-202)
   - [Version 2.0.1](#version-201)
   - [Version 2.0.0](#version-200)
 - [1.x.x](#1xx)
@@ -22,6 +23,10 @@ No migration is needed.
 However, starting in version 2, `backports.datetime_fromisoformat` will apply its changes to Python < 3.11, whereas v1 only applied changes to Python < 3.7. If you happened to be using `backports.datetime_fromisoformat` v1 on Python 3.7 through Python 3.10 and then upgrade to v2, it will patch the `fromisoformat` methods, whereas in v1 it did not. The `fromisoformat` methods will be able to parse timestamps from a wider portion of the ISO 8601 specification. This is unlikely to be a problem, but for completeness it is mentioned here.
 
 ## Unreleased
+
+* Nil.
+
+## Version 2.0.2
 
 * Add support for aarch64 wheels
 * Add builds for PyPy 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ However, starting in version 2, `backports.datetime_fromisoformat` will apply it
 ## Unreleased
 
 * Add support for aarch64 wheels
+* Add builds for PyPy 3.10
 
 ## Version 2.0.1
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,7 +17,7 @@ Make sure that there is a corresponding entry in `CHANGELOG.md`
 
 ## Create a developmental release
 
-The first step to *any* release is to excercise our build pipeline to make sure that our systems are still working as expected.
+The first step to *any* release is to exercise our build pipeline to make sure that our systems are still working as expected.
 (We release so infrequently, that there is often something that has broken due to "bit rot". You know how it is.)
 
 This is done with a ["developmental release"](https://peps.python.org/pep-0440) that executes the entire publishing process, including being uploaded to the [Test PyPI server](https://test.pypi.org/).
@@ -51,7 +51,7 @@ Only continue once you have a successful developmental release.
 
 ## Create a GitHub Release
 
-Once you have sucessfully uploaded and tested a developmental release, it's time for the real thing!
+Once you have successfully uploaded and tested a developmental release, it's time for the real thing!
 
 1. Create a new [GitHub release](https://github.com/movermeyer/backports.datetime_fromisoformat/releases/new)
 2. Click "Publish Release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build = [
     "cp312-*",
     "pp38-*",
     "pp39-*",
+    "pp310-*",
 ]
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,29 @@ Changelog = "https://github.com/movermeyer/backports.datetime_fromisoformat/CHAN
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.cibuildwheel]
+build = [
+    "cp38-*",
+    "cp39-*",
+    "cp310-*",
+    "cp311-*",
+    "cp312-*",
+    "pp38-*",
+    "pp39-*",
+]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" }
+skip = ["pp*"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+skip = ["pp*-win*", "*-win3"]
+
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 120
 disable = "C0114, C0115, C0116, C0301"


### PR DESCRIPTION
### What are you trying to accomplish?

Let's release with aarch64 wheels. 

### What approach did you choose and why?

Testing the changes proposed in https://github.com/closeio/ciso8601/pull/151

### What should reviewers focus on?

I'm going to merge this and try working through a release.

### The impact of these changes

🤞 We'll have aarch64 wheels.

### Testing

Manually running the Publish action against this PR seems to have worked: https://github.com/movermeyer/backports.datetime_fromisoformat/actions/runs/10774615549