### PR TITLE
Inline a copy of `_PyUnicode_Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ However, starting in version 2, `backports.datetime_fromisoformat` will apply it
 
 ## Unreleased
 
-* Nil.
+* Silenced errors when compiling against Python 3.13
+  * Note: `backports.datetime_fromisoformat` does nothing when used against Python 3.11+. Use `backports-datetime-fromisoformat; python_version < '3.11'` in your dependency list to avoid even downloading it in modern Pythons
 
 ## Version 2.0.2
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Quick Start
 
 .. code:: bash
 
-  pip install backports-datetime-fromisoformat
+  pip install "backports-datetime-fromisoformat; python_version < '3.11'"
 
 **Usage:**
 


### PR DESCRIPTION
### What are you trying to accomplish?

Silences compiler errors in Python 3.13. Fixes #61.

https://github.com/python/cpython/issues/106382 moved the `_PyUnicode` API functions elsewhere. 

### What approach did you choose and why?

Instead of backporting the current Python 3.13 datetimemodule.c code, I simply inlined the `_PyUnicode_Copy` method. Much easier.

I also changed the example `pip install` command in the README to include the `; python_version < '3.11'` version specifier, to hopefully encourage correct usage.

### What should reviewers focus on?

🤷 

### The impact of these changes

Silences compiler errors in Python 3.13.

While no one should bother using `backports.datetime_fromisoformat` with Python 3.13, people still do (presumably since they don't know to use `; python_version < '3.11'` in their dependencies).

### Testing

Build once again work in Python 3.13:

```bash
env_313/bin/python -m build
```