### PR TITLE
Release v2.0.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install lint tools
         run: "pip install Pygments restructuredtext-lint"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       requested_release_tag:
-        description: "The tag to use for this developmental release (without `.dev` suffix) (e.g., `v2.0.2`)"
+        description: "The tag to use for this developmental release (without `.dev` suffix) (e.g., `v2.0.3`)"
         required: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - run: |
           pip install packaging
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [2.x.x](#2xx)
   - [Migration from 1.x.x](#migration-from-1xx)
   - [Unreleased](#unreleased)
+  - [Version 2.0.3](#version-203)
   - [Version 2.0.2](#version-202)
   - [Version 2.0.1](#version-201)
   - [Version 2.0.0](#version-200)
@@ -23,6 +24,10 @@ No migration is needed.
 However, starting in version 2, `backports.datetime_fromisoformat` will apply its changes to Python < 3.11, whereas v1 only applied changes to Python < 3.7. If you happened to be using `backports.datetime_fromisoformat` v1 on Python 3.7 through Python 3.10 and then upgrade to v2, it will patch the `fromisoformat` methods, whereas in v1 it did not. The `fromisoformat` methods will be able to parse timestamps from a wider portion of the ISO 8601 specification. This is unlikely to be a problem, but for completeness it is mentioned here.
 
 ## Unreleased
+
+* Nil
+
+## Version 2.0.3
 
 * Silenced errors when compiling against Python 3.13
   * Note: `backports.datetime_fromisoformat` does nothing when used against Python 3.11+. Use `backports-datetime-fromisoformat; python_version < '3.11'` in your dependency list to avoid even downloading it in modern Pythons

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backports-datetime-fromisoformat"
-version = "2.0.2"
+version = "2.0.3"
 authors = [{ name = "Michael Overmeyer", email = "backports@movermeyer.com" }]
 description = "Backport of Python 3.11's datetime.fromisoformat"
 readme = "README.rst"


### PR DESCRIPTION
### What are you trying to accomplish?

Release a new version with the changes from #62  

### What approach did you choose and why?

Bump the version of. Following the instructions in [RELEASING.md](https://github.com/movermeyer/backports.datetime_fromisoformat/blob/872f4c8770dae953325e18a461a911cdec28b116/docs/RELEASING.md).

### What should reviewers focus on?

🤷

### The impact of these changes

Users of Python 3.13 who aren't using the `; python_version < '3.11'` will continue to not notice. 🤷 